### PR TITLE
Fix 404 errors by serving static files

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,20 +4,37 @@ const path = require('path');
 
 const port = process.env.PORT || 3000;
 
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif'
+};
+
 const server = http.createServer((req, res) => {
-  if (req.method === 'GET' && req.url === '/') {
-    fs.readFile(path.join(__dirname, 'public', 'index.html'), (err, data) => {
-      if (err) {
+  let filePath = req.url === '/' ? '/index.html' : req.url;
+  filePath = path.join(__dirname, 'public', filePath);
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404);
+        res.end('Not Found');
+      } else {
         res.writeHead(500);
-        return res.end('Server error');
+        res.end('Server Error');
       }
-      res.writeHead(200, { 'Content-Type': 'text/html' });
-      res.end(data);
-    });
-  } else {
-    res.writeHead(404);
-    res.end('Not Found');
-  }
+      return;
+    }
+
+    const ext = path.extname(filePath);
+    const contentType = mimeTypes[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  });
 });
 
 server.listen(port, () => {


### PR DESCRIPTION
## Summary
- handle requests for static files from the `public` folder

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_b_6862a7c16e40832c83b09442ef501ef3